### PR TITLE
Add awk alt fex and sed alt sd

### DIFF
--- a/programs.json
+++ b/programs.json
@@ -12,6 +12,14 @@
       ]
     },
     {
+      "name":"awk",
+      "description":"",
+      "url":"",
+      "alternatives":[
+        "fex"
+      ]
+    },
+    {
       "name":"bat",
       "description":"",
       "url":"https://github.com/sharkdp/bat",
@@ -25,6 +33,14 @@
       "url":"",
       "alternatives":[
         "bat"
+      ]
+    },
+    {
+      "name":"fex",
+      "description":"Like awk but simpler to use.",
+      "url":"https://www.semicomplete.com/projects/fex",
+      "alternatives":[
+        "awk"
       ]
     },
     {
@@ -45,6 +61,22 @@
         "ag",
         "grep",
         "ugrep"
+      ]
+    },
+    {
+      "name":"sed",
+      "description":"",
+      "url":"",
+      "alternatives":[
+        "sd"
+      ]
+    },
+    {
+      "name":"sd",
+      "description":"Simpler sed.",
+      "url":"https://github.com/chmln/sd",
+      "alternatives":[
+        "sed"
       ]
     },
     {


### PR DESCRIPTION
I found this looking for Hacktoberfest repos and thought it was a cool concept. I wanted to add two tools:
- An awk alternative called fex (Field EXtraction tool)
- A sed alternative called sd (basically sed but slightly simpler syntax)